### PR TITLE
Added support for Ethernet on ESP32 with W5500.

### DIFF
--- a/Firmware/USMArduinoFirmware/USMArduinoFirmware.ino
+++ b/Firmware/USMArduinoFirmware/USMArduinoFirmware.ino
@@ -842,6 +842,7 @@ void writeRegister(int adr, uint8_t reg, uint8_t data)
 // Reset the Wiznet Ethernet chip
 void resetWiznetChip()
 {
+#ifdef WIZNET_RESET_PIN
   Serial.print("Resetting Wiznet W5500 Ethernet chip...  ");
   pinMode(WIZNET_RESET_PIN, OUTPUT);
   digitalWrite(WIZNET_RESET_PIN, HIGH);
@@ -851,4 +852,5 @@ void resetWiznetChip()
   digitalWrite(WIZNET_RESET_PIN, HIGH);
   delay(350);
   Serial.println("Done.");
+#endif
 }

--- a/Firmware/USMArduinoFirmware/config.h.example
+++ b/Firmware/USMArduinoFirmware/config.h.example
@@ -36,6 +36,11 @@ const uint8_t MQTT_LWT_RETAIN       = 1;
 /* I2C */
 #define       I2C_CLOCK_SPEED         400000L  
              
+/* Ethernet - Uncomment only ONE "CS" option to suit your hardware */
+#define       ETHERNET_CS_PIN         26                    // Rack32 (ESP32) with W5500
+//#define       ETHERNET_CS_PIN         10                  // EtherMega (ATmega2560) with W5100
+#define       WIZNET_RESET_PIN        13
+
 /* MCP23017 */
 const byte    MCP_I2C_ADDRESS[]     = { 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27 };
 const uint8_t MCP_COUNT             = sizeof(MCP_I2C_ADDRESS);

--- a/Firmware/USMArduinoFirmware/config.h.example
+++ b/Firmware/USMArduinoFirmware/config.h.example
@@ -36,10 +36,12 @@ const uint8_t MQTT_LWT_RETAIN       = 1;
 /* I2C */
 #define       I2C_CLOCK_SPEED         400000L  
              
-/* Ethernet - Uncomment only ONE "CS" option to suit your hardware */
+/* Ethernet */
+// Uncomment only ONE "CS" option to suit your hardware:
 #define       ETHERNET_CS_PIN         26                    // Rack32 (ESP32) with W5500
-//#define       ETHERNET_CS_PIN         10                  // EtherMega (ATmega2560) with W5100
-#define       WIZNET_RESET_PIN        13
+//#define       ETHERNET_CS_PIN         10                    // EtherMega (ATmega2560) with W5100
+// Comment out the line below if your hardware doesn't have a Wiznet reset pin:
+#define       WIZNET_RESET_PIN        13                    // Rack32 (ESP32) with W5500
 
 /* MCP23017 */
 const byte    MCP_I2C_ADDRESS[]     = { 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27 };


### PR DESCRIPTION
Works, but some things still need to be checked / improved:
 * Getting the MAC address from ESP32 chip ID sets the last 2 bytes as 0x00 0x00. Needs investigation.
 * Currently does the W5500 chip reset process no matter what board it's running on. This should be conditional.